### PR TITLE
Use environment-based base URL for Dio

### DIFF
--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -1,0 +1,4 @@
+const String baseUrl = String.fromEnvironment(
+  'BASE_URL',
+  defaultValue: 'http://192.168.137.243:8000/api/v1',
+);

--- a/lib/core/network/dio_provider.dart
+++ b/lib/core/network/dio_provider.dart
@@ -3,6 +3,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import '../config.dart';
 import '../interceptors/auth_interceptor.dart';
 
 final secureStorageProvider = Provider<FlutterSecureStorage>((ref) {
@@ -13,7 +14,7 @@ final dioProvider = Provider<Dio>((ref) {
   final secureStorage = ref.read(secureStorageProvider);
 
   final dio = Dio(BaseOptions(
-    baseUrl: 'http://192.168.137.243:8000/api/v1', // 🔁 Personnalise ceci
+    baseUrl: baseUrl,
     connectTimeout: const Duration(seconds: 10),
     receiveTimeout: const Duration(seconds: 10),
     contentType: 'application/json',


### PR DESCRIPTION
## Summary
- add `lib/core/config.dart` to centralize base URL
- reference the constant in Dio provider

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685436ecd67883318d63db08c61a3d45