### PR TITLE
Fix refund status enum duplicates

### DIFF
--- a/lib/models/refund_status_enum.dart
+++ b/lib/models/refund_status_enum.dart
@@ -1,7 +1,12 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 enum RefundStatusEnum {
-  @JsonValue('PENDING') pending,
-  @JsonValue('APPROVED') approved,
-  @JsonValue('REJECTED') rejected, APPROVED, REJECTED, PENDING,
+  @JsonValue('PENDING')
+  pending,
+
+  @JsonValue('APPROVED')
+  approved,
+
+  @JsonValue('REJECTED')
+  rejected,
 }


### PR DESCRIPTION
## Summary
- clean up `RefundStatusEnum` definitions

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685439cd20808331b8f91179fe70516b